### PR TITLE
Adding display of offset for "Distance along path"

### DIFF
--- a/gci_ui.js
+++ b/gci_ui.js
@@ -1243,6 +1243,7 @@ function setVariables( )
 			showOffset(true);
 			showDistancePrecision(true);
 		} else if( index==3 ){ // Distance along path
+			showOffset(true);
 			showDistancePrecision(true);
 		} else if( index==4 ){ // Distance along orthogonal directions
 			showNSOffset(true);


### PR DESCRIPTION
"Offset Distance" is not displayed in the form for the "Distance along path" option . If I understand correctly, it should be displayed and this change should fix it.